### PR TITLE
Fix tool nuget package install

### DIFF
--- a/Documentation/GettingStarted/GettingStarted.md
+++ b/Documentation/GettingStarted/GettingStarted.md
@@ -9,13 +9,10 @@ uid: getting-started
 
 Git2SemVer requires:
 
-* `git` CLI to be callable from any project directory.
-* `dotnet` CLI to be callable from any project directory.
+* `git` CLI to be executable from any project directory.
+* `dotnet` CLI to be executable from any project directory.
 
 ## Installing
-
-> [!IMPORTANT]
-> Both `git` CLI and `dotnet` CLI must both be executable from any project directory on all build hosts.
 
 To setup a solution to use Git2SemVer solution versioning, first install the dotnet tool Git2SemVer.Tool:
 

--- a/Git2SemVer.Tool/Git2SemVer.Tool.csproj
+++ b/Git2SemVer.Tool/Git2SemVer.Tool.csproj
@@ -9,7 +9,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>git2semver</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>
-    <VersionPrefix>0.2.0</VersionPrefix>
+    <VersionPrefix>0.2.1</VersionPrefix>
     <Title>Simple automatic Git to Semantic Versioning for .NET projects.</Title>
     <Description>Automated Semantic Versioning for Visual Studio and dotnet cli.</Description>
     <PackageProjectUrl>https://github.com/NoeticTools/Git2SemVer</PackageProjectUrl>

--- a/Git2SemVer.Tool/Git2SemVer.Tool.csproj
+++ b/Git2SemVer.Tool/Git2SemVer.Tool.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <PackAsTool>false</PackAsTool>
+    <PackAsTool>true</PackAsTool>
     <ToolCommandName>git2semver</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>
     <VersionPrefix>0.2.0</VersionPrefix>


### PR DESCRIPTION
# Description

Dotnet tool (Git2SemVer.Tool) was not installing by `dotnet tool install` command as the NuGet package was not packaged as a tool.

# Testing

Deployed new package to local server and installed manually.
