### PR TITLE
Tool not adding folders correctly

### DIFF
--- a/Documentation/GettingStarted/GettingStarted.md
+++ b/Documentation/GettingStarted/GettingStarted.md
@@ -26,7 +26,7 @@ dotnet tool install --global NoeticTools.Git2SemVer.Tool
 Then, in the solution's directory, run:
 
 ```winbatch
-Git2SemVer setup
+Git2SemVer add
 ```
 
 You will be prompted with a few options and then setup is done. :-)

--- a/Git2SemVer.Tool/Commands/RemoveCommand/RemoveCommand.cs
+++ b/Git2SemVer.Tool/Commands/RemoveCommand/RemoveCommand.cs
@@ -78,7 +78,6 @@ internal sealed class RemoveCommand : IRemoveCommand
         _console.WriteLine();
         changeMade |= RemoveDirectoryPropertiesInclude(solutionDirectory);
         changeMade |= DeleteDirectoryVersioningPropertiesFile(solutionDirectory);
-        changeMade |= DeleteSharedDirectory(solutionDirectory);
         changeMade |= DeleteVersioningProjectFolder(solutionDirectory, leaderProjectName);
         changeMade |= RemoveVersioningProjectFromSolution(solution, leaderProjectName);
 
@@ -112,20 +111,6 @@ internal sealed class RemoveCommand : IRemoveCommand
         }
 
         _console.WriteWarningLine($"\t- No change. Properties file '{directoryVersioningPropsFile.Name}' not found.");
-        return false;
-    }
-
-    private bool DeleteSharedDirectory(DirectoryInfo solutionDirectory)
-    {
-        var sharedDirectory = solutionDirectory.WithSubDirectory(Git2SemverConstants.ShareFolderName);
-        if (sharedDirectory.Exists)
-        {
-            sharedDirectory.Delete(true);
-            _console.WriteInfoLine($"\t- Deleted shared version folder: '{sharedDirectory.Name}.");
-            return true;
-        }
-
-        _console.WriteWarningLine($"\t- No change. Version share directory '{sharedDirectory.Name}' not found.");
         return false;
     }
 

--- a/Git2SemVer.Tool/Commands/SetupCommand/AddCommand.cs
+++ b/Git2SemVer.Tool/Commands/SetupCommand/AddCommand.cs
@@ -77,7 +77,6 @@ internal sealed class AddCommand : ISetupCommand
         propertiesDocument.Properties["Git2SemVer_VersioningProjectName"].Value = userOptions.VersioningProjectName;
 
         CreateVersioningProject(userOptions, solution);
-        CreateSharedDirectory(solutionDirectory);
         SetupGitIgnore(solutionDirectory);
 
         if (_console.HasError)
@@ -109,9 +108,9 @@ internal sealed class AddCommand : ISetupCommand
         return _projectDocumentReader.Read(versioningPropsFile);
     }
 
-    private void CreateSharedDirectory(DirectoryInfo solutionDirectory)
+    private void CreateSharedDirectory(DirectoryInfo parentDirectory)
     {
-        var sharedDirectory = solutionDirectory.WithSubDirectory(Git2SemverConstants.ShareFolderName);
+        var sharedDirectory = parentDirectory.WithSubDirectory(Git2SemverConstants.ShareFolderName);
         if (sharedDirectory.Exists)
         {
             _logger.WriteTraceLine("`{0}` already existed. Overwriting files in directory.", sharedDirectory.Name);
@@ -122,7 +121,7 @@ internal sealed class AddCommand : ISetupCommand
         _embeddedResources.WriteResourceFile(Git2SemverConstants.SharedVersionPropertiesFilename, sharedDirectory);
         _embeddedResources.WriteResourceFile(Git2SemverConstants.SharedEnvPropertiesFilename, sharedDirectory);
 
-        _console.WriteInfoLine($"\t- Added '{Git2SemverConstants.ShareFolderName}' shared directory to solution directory.");
+        _console.WriteInfoLine($"\t- Added '{Git2SemverConstants.ShareFolderName}' shared directory to versioning project directory.");
     }
 
     private void CreateVersioningProject(UserOptions userOptions, FileInfo solution)
@@ -133,6 +132,9 @@ internal sealed class AddCommand : ISetupCommand
         var csxFileDestination = solution.Directory!.WithSubDirectory(projectName).WithFile(Git2SemverConstants.DefaultScriptFilename);
         _embeddedResources.WriteResourceFile(Git2SemverConstants.DefaultScriptFilename, csxFileDestination.FullName);
         _console.WriteInfoLine($"\t- Added '{projectName}' project to solution.");
+
+        var versioningProjectDirectory = solution.Directory!;
+        CreateSharedDirectory(versioningProjectDirectory);
     }
 
     private void PrepareDirectoryBuildPropsFile(DirectoryInfo directory)

--- a/Git2SemVer.Tool/Commands/SetupCommand/AddCommand.cs
+++ b/Git2SemVer.Tool/Commands/SetupCommand/AddCommand.cs
@@ -115,7 +115,6 @@ internal sealed class AddCommand : ISetupCommand
         {
             _logger.WriteTraceLine("`{0}` already existed. Overwriting files in directory.", sharedDirectory.Name);
         }
-
         sharedDirectory.Create();
 
         _embeddedResources.WriteResourceFile(Git2SemverConstants.SharedVersionPropertiesFilename, sharedDirectory);
@@ -133,7 +132,7 @@ internal sealed class AddCommand : ISetupCommand
         _embeddedResources.WriteResourceFile(Git2SemverConstants.DefaultScriptFilename, csxFileDestination.FullName);
         _console.WriteInfoLine($"\t- Added '{projectName}' project to solution.");
 
-        var versioningProjectDirectory = solution.Directory!;
+        var versioningProjectDirectory = solution.Directory!.WithSubDirectory(userOptions.VersioningProjectName);
         CreateSharedDirectory(versioningProjectDirectory);
     }
 

--- a/Git2SemVer.Tool/Commands/SetupCommand/UserAddSolutionVersioningOptionsPrompt.cs
+++ b/Git2SemVer.Tool/Commands/SetupCommand/UserAddSolutionVersioningOptionsPrompt.cs
@@ -21,8 +21,7 @@ internal sealed class UserAddSolutionVersioningOptionsPrompt : IUserOptionsPromp
 
     public UserOptions GetOptions(FileInfo solution)
     {
-        _console.MarkupLine("Projects in the current directory and sub directories will be configured to use Git2SemVer solution versioning. " +
-                            "A versioning project will be added to the solution '[em]{solution.Name}[/]' and solution versioning directory properties files will be added to the current directory.");
+        _console.MarkupLine($"Projects in the current directory and sub directories will be configured to use Git2SemVer solution versioning. A versioning project will be added to the solution '[em]{solution.Name}[/]' and solution versioning directory properties files will be added to the current directory.");
 
         var leadingProjectName = _console.Prompt(new TextPrompt<string>("Versioning project name?")
                                                      .Validate(folderName => ValidateFolderDoesNotExist(folderName, solution.Directory!)),

--- a/Git2SemVer.Tool/Git2SemVer.Tool.csproj
+++ b/Git2SemVer.Tool/Git2SemVer.Tool.csproj
@@ -9,7 +9,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>git2semver</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>
-    <VersionPrefix>0.2.3</VersionPrefix>
+    <VersionPrefix>0.2.4</VersionPrefix>
     <Title>Simple automatic Git to Semantic Versioning for .NET projects.</Title>
     <Description>Automated Semantic Versioning for Visual Studio and dotnet cli.</Description>
     <PackageProjectUrl>https://github.com/NoeticTools/Git2SemVer</PackageProjectUrl>

--- a/Git2SemVer.Tool/Git2SemVer.Tool.csproj
+++ b/Git2SemVer.Tool/Git2SemVer.Tool.csproj
@@ -9,7 +9,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>git2semver</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>
-    <VersionPrefix>0.2.1</VersionPrefix>
+    <VersionPrefix>0.2.3</VersionPrefix>
     <Title>Simple automatic Git to Semantic Versioning for .NET projects.</Title>
     <Description>Automated Semantic Versioning for Visual Studio and dotnet cli.</Description>
     <PackageProjectUrl>https://github.com/NoeticTools/Git2SemVer</PackageProjectUrl>


### PR DESCRIPTION
# Description

Git2SemVer.Tools was not creating the shared versioning folder in the same directory expected by the runtime Git2SemVer.MSBuild. Fixed this.

Also corrected getting started documentation.

# Testing

Tested locally on sample project.