### PR TITLE
Issue passing build number into MSBuild task

### DIFF
--- a/Documentation/Usage/BuildHosts/GitHubWorkflows.md
+++ b/Documentation/Usage/BuildHosts/GitHubWorkflows.md
@@ -32,8 +32,8 @@ In a github workflow yml pass these two numbers to Git2SemVer like this:
           RUN_NUMBER: ${{ github.run_number }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
       run: |
-          dotnet build MyApplication.sln -p:Git2SemVer_BuidNumber=${{ env.run_number }} \
-                                         -p:Git2SemVer_BuidContext=${{ env.run_attempt }} \
+          dotnet build MyApplication.sln -p:Git2SemVer_BuildNumber=${{ env.run_number }} \
+                                         -p:Git2SemVer_BuildContext=${{ env.run_attempt }} \
                                          -p:Git2SemVer_Env_HostType=GitHub
 ```
 

--- a/Git2SemVer.MSBuild/Build/NoeticTools.Git2SemVer.MSBuild.targets
+++ b/Git2SemVer.MSBuild/Build/NoeticTools.Git2SemVer.MSBuild.targets
@@ -21,7 +21,7 @@
 
     <!-- Generate version information -->
 
-    <Git2SemVerGenerateVersionTask Input_BuildNumber="$(Git2SemVer_BuidNumber)"
+    <Git2SemVerGenerateVersionTask Input_BuildNumber="$(Git2SemVer_BuildNumber)"
                                    Input_BuildContext="$(Git2SemVer_BuildContext)"
                                    Input_BuildIdFormat="$(Git2SemVer_BuildIDFormat)"
                                    Input_Version="$(Version)"

--- a/Git2SemVer.MSBuild/Git2SemVer.MSBuild.csproj
+++ b/Git2SemVer.MSBuild/Git2SemVer.MSBuild.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <VersionPrefix>0.11.4</VersionPrefix>
+    <VersionPrefix>0.11.5</VersionPrefix>
     <Title>Simple automatic Git to Semantic Versioning for .NET projects.</Title>
     <Description>Automated Semantic Versioning for Visual Studio and dotnet CLI.</Description>
     <PackageProjectUrl>https://github.com/NoeticTools/Git2SemVer</PackageProjectUrl>

--- a/Git2SemVer.MSBuild/Tools/CI/BuildHostBase.cs
+++ b/Git2SemVer.MSBuild/Tools/CI/BuildHostBase.cs
@@ -17,7 +17,7 @@ internal abstract class BuildHostBase : ToolBase
     protected BuildHostBase(ILogger logger)
     {
         _logger = logger;
-        _defaultBuildNumberFunc = () => [$"{BuildNumber}"];
+        _defaultBuildNumberFunc = () => [BuildNumber];
         _buildNumberFunc = _defaultBuildNumberFunc;
     }
 


### PR DESCRIPTION
# Description

On GitHub build the build number was being passed correctly to the MSBuild versioning task due to a property typo.

# Testing

Tested on TeamCity.