### PR TITLE
Adding team city build label

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,11 +1,6 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>0.14.1</VersionPrefix>
-    <VersionSuffix>InitialDev</VersionSuffix>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>0.14.0</VersionPrefix>
+    <VersionPrefix>0.14.1</VersionPrefix>
     <VersionSuffix>InitialDev</VersionSuffix>
   </PropertyGroup>
 

--- a/Git2SemVer.MSBuild/Directory.Build.targets
+++ b/Git2SemVer.MSBuild/Directory.Build.targets
@@ -1,0 +1,6 @@
+<Project>
+  <!-- See https://aka.ms/dotnet/msbuild/customize for more details on customizing your build -->
+  <Target Name="CustomAfterBuildTarget" AfterTargets="Build">
+      <Message Text="Hello from CustomAfterBuildTarget" Importance="high" />
+  </Target>
+</Project>

--- a/Git2SemVer.MSBuild/Git2SemVer.MSBuild.csproj
+++ b/Git2SemVer.MSBuild/Git2SemVer.MSBuild.csproj
@@ -60,7 +60,7 @@
     <TeamCityBuildLabel Condition=" '$(VersionSuffix)' != '' ">$(VersionPrefix)-$(VersionSuffix).$(TeamCityBuildNumber)</TeamCityBuildLabel>
   </PropertyGroup>
   <Target Name="SetTeamCityBuildLabel" 
-          BeforeTargets="DispatchToInnerBuilds" 
+          BeforeTargets="Pack;GenerateNuspec" 
           Condition=" '$(TeamCityHostDetected)' == 'true' ">
     <Message Text="##teamcity[buildNumber '$(TeamCityBuildLabel)']" Importance="high" />
   </Target>

--- a/Git2SemVer.MSBuild/Git2SemVer.MSBuild.csproj
+++ b/Git2SemVer.MSBuild/Git2SemVer.MSBuild.csproj
@@ -52,8 +52,8 @@
 
   <!-- Set TeamCity build label to semmantic version. Does not work if build verbosity is minimal or quiet. -->
   <PropertyGroup>
-    <TeamCityHostDetected Condition=" '$(TEAMCITY_VERSION)' != '' ">false</TeamCityHostDetected>
-    <TeamCityHostDetected Condition=" '$(TeamCityHostDetected)' == '' ">true</TeamCityHostDetected>
+    <TeamCityHostDetected Condition=" '$(TEAMCITY_VERSION)' != '' ">true</TeamCityHostDetected>
+    <TeamCityHostDetected Condition=" '$(TeamCityHostDetected)' == '' ">false</TeamCityHostDetected>
     <TeamCityBuildNumber Condition=" '$(TeamCityHostDetected)' == 'true' ">$(BUILD_NUMBER)</TeamCityBuildNumber>
     <TeamCityBuildNumber Condition=" '$(TeamCityBuildNumber)' == '' ">0</TeamCityBuildNumber>
     <TeamCityBuildLabel Condition=" '$(VersionSuffix)' == '' ">$(VersionPrefix)+$(TeamCityBuildNumber)</TeamCityBuildLabel>

--- a/Git2SemVer.MSBuild/Git2SemVer.MSBuild.csproj
+++ b/Git2SemVer.MSBuild/Git2SemVer.MSBuild.csproj
@@ -45,6 +45,21 @@
     </AssemblyAttribute>
   </ItemGroup>
 
+  <!-- Set TeamCity build label to semmantic version. Does not work if build verbosity is minimal or quiet. -->
+  <PropertyGroup>
+    <TeamCityHostDetected Condition=" '$(TEAMCITY_VERSION)' != '' ">true</TeamCityHostDetected>
+    <TeamCityHostDetected Condition=" '$(TeamCityHostDetected)' == '' ">true</TeamCityHostDetected>
+    <TeamCityBuildNumber Condition=" '$(TeamCityHostDetected)' == 'true' ">$(BUILD_NUMBER)</TeamCityBuildNumber>
+    <TeamCityBuildNumber Condition=" '$(TeamCityBuildNumber)' == '' ">0</TeamCityBuildNumber>
+    <TeamCityBuildLabel Condition=" '$(VersionSuffix)' == '' ">$(VersionPrefix)+$(TeamCityBuildNumber)</TeamCityBuildLabel>
+    <TeamCityBuildLabel Condition=" '$(VersionSuffix)' != '' ">$(VersionPrefix)-$(VersionSuffix).$(TeamCityBuildNumber)</TeamCityBuildLabel>
+  </PropertyGroup>
+  <Target Name="SetTeamCityBuildLabel" 
+          BeforeTargets="Build" 
+          Condition=" '$(TeamCityHostDetected)' == 'true' ">
+    <Message Text="##teamcity[buildNumber '$(TeamCityBuildLabel)']" Importance="high" />
+  </Target>
+
   <Target Name="AddBuildDependencyFileToBuiltProjectOutputGroupOutput" BeforeTargets="BuiltProjectOutputGroup" Condition=" '$(GenerateDependencyFile)' == 'true'">
     <ItemGroup>
       <BuiltProjectOutputGroupOutput Include="$(ProjectDepsFilePath)" TargetPath="$(ProjectDepsFileName)" FinalOutputPath="$(ProjectDepsFilePath)" />

--- a/Git2SemVer.MSBuild/Git2SemVer.MSBuild.csproj
+++ b/Git2SemVer.MSBuild/Git2SemVer.MSBuild.csproj
@@ -50,20 +50,7 @@
     </AssemblyAttribute>
   </ItemGroup>
 
-  <!-- Set TeamCity build label to semmantic version. Does not work if build verbosity is minimal or quiet. -->
-  <PropertyGroup>
-    <TeamCityHostDetected Condition=" '$(TEAMCITY_VERSION)' != '' ">true</TeamCityHostDetected>
-    <TeamCityHostDetected Condition=" '$(TeamCityHostDetected)' == '' ">true</TeamCityHostDetected>
-    <TeamCityBuildNumber Condition=" '$(TeamCityHostDetected)' == 'true' ">$(BUILD_NUMBER)</TeamCityBuildNumber>
-    <TeamCityBuildNumber Condition=" '$(TeamCityBuildNumber)' == '' ">0</TeamCityBuildNumber>
-    <TeamCityBuildLabel Condition=" '$(VersionSuffix)' == '' ">$(VersionPrefix)+$(TeamCityBuildNumber)</TeamCityBuildLabel>
-    <TeamCityBuildLabel Condition=" '$(VersionSuffix)' != '' ">$(VersionPrefix)-$(VersionSuffix).$(TeamCityBuildNumber)</TeamCityBuildLabel>
-  </PropertyGroup>
-  <Target Name="SetTeamCityBuildLabel" 
-          BeforeTargets="Pack;GenerateNuspec" 
-          Condition=" '$(TeamCityHostDetected)' == 'true' And '$(BUILD_NUMBER.Contains(`.`))' == 'false'  ">
-    <Message Text="##teamcity[buildNumber '$(TeamCityBuildLabel)']" Importance="high" />
-  </Target>
+  <Import Project="TeamCity.targets" />
 
   <Target Name="AddBuildDependencyFileToBuiltProjectOutputGroupOutput" BeforeTargets="BuiltProjectOutputGroup" Condition=" '$(GenerateDependencyFile)' == 'true'">
     <ItemGroup>

--- a/Git2SemVer.MSBuild/Git2SemVer.MSBuild.csproj
+++ b/Git2SemVer.MSBuild/Git2SemVer.MSBuild.csproj
@@ -5,6 +5,11 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <VersionPrefix>0.14.1</VersionPrefix>
+    <VersionSuffix>InitialDev</VersionSuffix>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <Title>Simple automatic Git to Semantic Versioning for .NET projects.</Title>
     <Description>Automated Semantic Versioning for Visual Studio and dotnet CLI.</Description>
     <PackageProjectUrl>https://github.com/NoeticTools/Git2SemVer</PackageProjectUrl>
@@ -47,7 +52,7 @@
 
   <!-- Set TeamCity build label to semmantic version. Does not work if build verbosity is minimal or quiet. -->
   <PropertyGroup>
-    <TeamCityHostDetected Condition=" '$(TEAMCITY_VERSION)' != '' ">true</TeamCityHostDetected>
+    <TeamCityHostDetected Condition=" '$(TEAMCITY_VERSION)' != '' ">false</TeamCityHostDetected>
     <TeamCityHostDetected Condition=" '$(TeamCityHostDetected)' == '' ">true</TeamCityHostDetected>
     <TeamCityBuildNumber Condition=" '$(TeamCityHostDetected)' == 'true' ">$(BUILD_NUMBER)</TeamCityBuildNumber>
     <TeamCityBuildNumber Condition=" '$(TeamCityBuildNumber)' == '' ">0</TeamCityBuildNumber>
@@ -55,7 +60,7 @@
     <TeamCityBuildLabel Condition=" '$(VersionSuffix)' != '' ">$(VersionPrefix)-$(VersionSuffix).$(TeamCityBuildNumber)</TeamCityBuildLabel>
   </PropertyGroup>
   <Target Name="SetTeamCityBuildLabel" 
-          BeforeTargets="Build" 
+          BeforeTargets="DispatchToInnerBuilds" 
           Condition=" '$(TeamCityHostDetected)' == 'true' ">
     <Message Text="##teamcity[buildNumber '$(TeamCityBuildLabel)']" Importance="high" />
   </Target>

--- a/Git2SemVer.MSBuild/Git2SemVer.MSBuild.csproj
+++ b/Git2SemVer.MSBuild/Git2SemVer.MSBuild.csproj
@@ -53,7 +53,7 @@
   <!-- Set TeamCity build label to semmantic version. Does not work if build verbosity is minimal or quiet. -->
   <PropertyGroup>
     <TeamCityHostDetected Condition=" '$(TEAMCITY_VERSION)' != '' ">true</TeamCityHostDetected>
-    <TeamCityHostDetected Condition=" '$(TeamCityHostDetected)' == '' ">false</TeamCityHostDetected>
+    <TeamCityHostDetected Condition=" '$(TeamCityHostDetected)' == '' ">true</TeamCityHostDetected>
     <TeamCityBuildNumber Condition=" '$(TeamCityHostDetected)' == 'true' ">$(BUILD_NUMBER)</TeamCityBuildNumber>
     <TeamCityBuildNumber Condition=" '$(TeamCityBuildNumber)' == '' ">0</TeamCityBuildNumber>
     <TeamCityBuildLabel Condition=" '$(VersionSuffix)' == '' ">$(VersionPrefix)+$(TeamCityBuildNumber)</TeamCityBuildLabel>
@@ -61,7 +61,7 @@
   </PropertyGroup>
   <Target Name="SetTeamCityBuildLabel" 
           BeforeTargets="Pack;GenerateNuspec" 
-          Condition=" '$(TeamCityHostDetected)' == 'true' ">
+          Condition=" '$(TeamCityHostDetected)' == 'true' And '$(BUILD_NUMBER.Contains(`.`))' == 'false'  ">
     <Message Text="##teamcity[buildNumber '$(TeamCityBuildLabel)']" Importance="high" />
   </Target>
 

--- a/Git2SemVer.MSBuild/TeamCity.targets
+++ b/Git2SemVer.MSBuild/TeamCity.targets
@@ -1,0 +1,28 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<Project>
+
+  <!-- 
+  Set TeamCity build label to semmantic version. 
+  
+  Only works if:
+
+  - Build verbosity is not minimal or quiet. 
+  - A NuGet package build is performed.
+  -->
+
+  <PropertyGroup>
+    <TeamCityHostDetected Condition=" '$(TEAMCITY_VERSION)' != '' ">true</TeamCityHostDetected>
+    <TeamCityHostDetected Condition=" '$(TeamCityHostDetected)' == '' ">true</TeamCityHostDetected>
+    <TeamCityBuildNumber Condition=" '$(TeamCityHostDetected)' == 'true' ">$(BUILD_NUMBER)</TeamCityBuildNumber>
+    <TeamCityBuildNumber Condition=" '$(TeamCityBuildNumber)' == '' ">0</TeamCityBuildNumber>
+    <TeamCityBuildLabel Condition=" '$(VersionSuffix)' == '' ">$(VersionPrefix)+$(TeamCityBuildNumber)</TeamCityBuildLabel>
+    <TeamCityBuildLabel Condition=" '$(VersionSuffix)' != '' ">$(VersionPrefix)-$(VersionSuffix).$(TeamCityBuildNumber)</TeamCityBuildLabel>
+  </PropertyGroup>
+  <Target Name="SetTeamCityBuildLabel" 
+          BeforeTargets="Pack;GenerateNuspec" 
+          Condition=" '$(TeamCityHostDetected)' == 'true' And '$(BUILD_NUMBER.Contains(`.`))' == 'false'  ">
+    <Message Text="##teamcity[buildNumber '$(TeamCityBuildLabel)']" Importance="high" />
+  </Target>
+
+</Project>

--- a/Git2SemVer.MSBuild/TeamCity.targets
+++ b/Git2SemVer.MSBuild/TeamCity.targets
@@ -13,7 +13,7 @@
 
   <PropertyGroup>
     <TeamCityHostDetected Condition=" '$(TEAMCITY_VERSION)' != '' ">true</TeamCityHostDetected>
-    <TeamCityHostDetected Condition=" '$(TeamCityHostDetected)' == '' ">true</TeamCityHostDetected>
+    <TeamCityHostDetected Condition=" '$(TeamCityHostDetected)' == '' ">false</TeamCityHostDetected>
     <TeamCityBuildNumber Condition=" '$(TeamCityHostDetected)' == 'true' ">$(BUILD_NUMBER)</TeamCityBuildNumber>
     <TeamCityBuildNumber Condition=" '$(TeamCityBuildNumber)' == '' ">0</TeamCityBuildNumber>
     <TeamCityBuildLabel Condition=" '$(VersionSuffix)' == '' ">$(VersionPrefix)+$(TeamCityBuildNumber)</TeamCityBuildLabel>


### PR DESCRIPTION
# Description

This Git2SemVer project cannot use itself to version itself as adding the NuGet package results in circular references :-(. So this PR adds MSBuild targets file to update the build label on a TeamCity build. The version still needs to be manually udpated in the code.