### PR TITLE
feat: Add cross-targeting project versioning

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added [Cross targeted projects](https://learn.microsoft.com/en-us/nuget/create-packages/multiple-target-frameworks-project-file) support ([#26](https://github.com/NoeticTools/Git2SemVer/issues/26)).
 * Added versioning log file ([#26](https://github.com/NoeticTools/Git2SemVer/issues/2)).
+* Added [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.2/) support for versioning.
 
 ### Fixed
 

--- a/EditingTestAssembly/EditingTestAssembly.csproj
+++ b/EditingTestAssembly/EditingTestAssembly.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.68" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.70" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EditingTestAssembly/EditingTestAssembly.csproj
+++ b/EditingTestAssembly/EditingTestAssembly.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.72" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.73" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EditingTestAssembly/EditingTestAssembly.csproj
+++ b/EditingTestAssembly/EditingTestAssembly.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.73" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-InitialDev.74" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EditingTestAssembly/EditingTestAssembly.csproj
+++ b/EditingTestAssembly/EditingTestAssembly.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.72" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.68" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EditingTestAssembly/EditingTestAssembly.csproj
+++ b/EditingTestAssembly/EditingTestAssembly.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.70" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.68" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EditingTestAssembly/EditingTestAssembly.csproj
+++ b/EditingTestAssembly/EditingTestAssembly.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.68" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.72" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Git2SemVer.IntegrationTests/Git2SemVer.IntegrationTests.csproj
+++ b/Git2SemVer.IntegrationTests/Git2SemVer.IntegrationTests.csproj
@@ -31,7 +31,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.72" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.73" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>

--- a/Git2SemVer.IntegrationTests/Git2SemVer.IntegrationTests.csproj
+++ b/Git2SemVer.IntegrationTests/Git2SemVer.IntegrationTests.csproj
@@ -31,7 +31,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.68" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.72" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>

--- a/Git2SemVer.IntegrationTests/Git2SemVer.IntegrationTests.csproj
+++ b/Git2SemVer.IntegrationTests/Git2SemVer.IntegrationTests.csproj
@@ -31,7 +31,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.68" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.70" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>

--- a/Git2SemVer.IntegrationTests/Git2SemVer.IntegrationTests.csproj
+++ b/Git2SemVer.IntegrationTests/Git2SemVer.IntegrationTests.csproj
@@ -31,7 +31,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.72" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.68" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>

--- a/Git2SemVer.IntegrationTests/Git2SemVer.IntegrationTests.csproj
+++ b/Git2SemVer.IntegrationTests/Git2SemVer.IntegrationTests.csproj
@@ -31,7 +31,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.73" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-InitialDev.74" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>

--- a/Git2SemVer.IntegrationTests/Git2SemVer.IntegrationTests.csproj
+++ b/Git2SemVer.IntegrationTests/Git2SemVer.IntegrationTests.csproj
@@ -31,7 +31,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.70" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.68" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>

--- a/Git2SemVer.MSBuild.IntegrationTests/Git2SemVer.MSBuild.IntegrationTests.csproj
+++ b/Git2SemVer.MSBuild.IntegrationTests/Git2SemVer.MSBuild.IntegrationTests.csproj
@@ -36,7 +36,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.68" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.72" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>

--- a/Git2SemVer.MSBuild.IntegrationTests/Git2SemVer.MSBuild.IntegrationTests.csproj
+++ b/Git2SemVer.MSBuild.IntegrationTests/Git2SemVer.MSBuild.IntegrationTests.csproj
@@ -36,7 +36,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.72" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.73" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>

--- a/Git2SemVer.MSBuild.IntegrationTests/Git2SemVer.MSBuild.IntegrationTests.csproj
+++ b/Git2SemVer.MSBuild.IntegrationTests/Git2SemVer.MSBuild.IntegrationTests.csproj
@@ -36,7 +36,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.68" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.70" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>

--- a/Git2SemVer.MSBuild.IntegrationTests/Git2SemVer.MSBuild.IntegrationTests.csproj
+++ b/Git2SemVer.MSBuild.IntegrationTests/Git2SemVer.MSBuild.IntegrationTests.csproj
@@ -36,7 +36,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.72" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.68" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>

--- a/Git2SemVer.MSBuild.IntegrationTests/Git2SemVer.MSBuild.IntegrationTests.csproj
+++ b/Git2SemVer.MSBuild.IntegrationTests/Git2SemVer.MSBuild.IntegrationTests.csproj
@@ -36,7 +36,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.73" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-InitialDev.74" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>

--- a/Git2SemVer.MSBuild.IntegrationTests/Git2SemVer.MSBuild.IntegrationTests.csproj
+++ b/Git2SemVer.MSBuild.IntegrationTests/Git2SemVer.MSBuild.IntegrationTests.csproj
@@ -36,7 +36,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.70" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.68" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>

--- a/Git2SemVer.MSBuild.Tests/Git2SemVer.MSBuild.Tests.csproj
+++ b/Git2SemVer.MSBuild.Tests/Git2SemVer.MSBuild.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.73" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-InitialDev.74" />
     <PackageReference Include="NuGet.Versioning" Version="6.11.1" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0">

--- a/Git2SemVer.MSBuild.Tests/Git2SemVer.MSBuild.Tests.csproj
+++ b/Git2SemVer.MSBuild.Tests/Git2SemVer.MSBuild.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.72" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.73" />
     <PackageReference Include="NuGet.Versioning" Version="6.11.1" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0">

--- a/Git2SemVer.MSBuild.Tests/Git2SemVer.MSBuild.Tests.csproj
+++ b/Git2SemVer.MSBuild.Tests/Git2SemVer.MSBuild.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.68" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.70" />
     <PackageReference Include="NuGet.Versioning" Version="6.11.1" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0">

--- a/Git2SemVer.MSBuild.Tests/Git2SemVer.MSBuild.Tests.csproj
+++ b/Git2SemVer.MSBuild.Tests/Git2SemVer.MSBuild.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.68" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.72" />
     <PackageReference Include="NuGet.Versioning" Version="6.11.1" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0">

--- a/Git2SemVer.MSBuild.Tests/Git2SemVer.MSBuild.Tests.csproj
+++ b/Git2SemVer.MSBuild.Tests/Git2SemVer.MSBuild.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.70" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.68" />
     <PackageReference Include="NuGet.Versioning" Version="6.11.1" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0">

--- a/Git2SemVer.MSBuild.Tests/Git2SemVer.MSBuild.Tests.csproj
+++ b/Git2SemVer.MSBuild.Tests/Git2SemVer.MSBuild.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.72" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.68" />
     <PackageReference Include="NuGet.Versioning" Version="6.11.1" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0">

--- a/Git2SemVer.MSBuild.Tests/Versioning/Generation/GitHistoryWalking/GitHistoryWalkingTestsBase.cs
+++ b/Git2SemVer.MSBuild.Tests/Versioning/Generation/GitHistoryWalking/GitHistoryWalkingTestsBase.cs
@@ -33,6 +33,7 @@ internal abstract class GitHistoryWalkingTestsBase
         return commits;
     }
 
+    [SetUp]
     protected void SetupBase()
     {
         VersionHistorySegment.Reset();
@@ -41,5 +42,11 @@ internal abstract class GitHistoryWalkingTestsBase
         Logger = new NUnitLogger(false) { Level = LoggingLevel.Trace };
         Repository = new Mock<ICommitsRepository>();
         _gitTool = new GitTool(Logger);
+    }
+
+    [TearDown]
+    protected void TearDownBase()
+    {
+        Logger.Dispose();
     }
 }

--- a/Git2SemVer.MSBuild.Tests/Versioning/Generation/GitHistoryWalking/PathsFromLastReleasesFinderTests.cs
+++ b/Git2SemVer.MSBuild.Tests/Versioning/Generation/GitHistoryWalking/PathsFromLastReleasesFinderTests.cs
@@ -25,12 +25,6 @@ internal class PathsFromLastReleasesFinderTests : GitHistoryWalkingTestsBase
         _gitTool.Setup(x => x.BranchName).Returns("BranchName");
     }
 
-    [TearDown]
-    public void TearDown()
-    {
-        Logger.Dispose();
-    }
-
     [TestCaseSource(typeof(ScenariosFromBuildLogsTestSource))]
     public void BasicScenariosTest(string name, LoggedScenario scenario)
     {

--- a/Git2SemVer.MSBuild.Tests/Versioning/Generation/GitHistoryWalking/ScenariosFromBuildLogsTestSource.cs
+++ b/Git2SemVer.MSBuild.Tests/Versioning/Generation/GitHistoryWalking/ScenariosFromBuildLogsTestSource.cs
@@ -262,6 +262,57 @@ internal sealed class ScenariosFromBuildLogsTestSource : IEnumerable
                               *               {US}.|0003|0004|{STX}REDACTED{ETX}|{STX}{ETX}||
                               """);
 
+    /// <summary>
+    ///     Actual failure scenario from logs. Was returning 1.0.1 instead of 1.1.0.
+    /// </summary>
+    public LoggedScenario Scenario12 { get; } =
+        new("1.1.0", "0002", """
+                              *               .|0002|0003|REDACTED|| (HEAD -> REDACTED_BRANCH, origin/Investigating)|
+                              *               .|0003|0004 0005|REDACTED|| (origin/REDACTED_BRANCH, main)|
+                              | *             .|0005|0006|REDACTED|| (origin/REDACTED_BRANCH, feature/cross-targeting)|
+                              | *             .|0006|0007|refactor: REDACTED|||
+                              | *             .|0007|0008|test: REDACTED|||
+                              | *             .|0008|0009|test: REDACTED|||
+                              | *             .|0009|0010|test: REDACTED|||
+                              | *             .|0010|0011|refactor: REDACTED|||
+                              | *             .|0011|0012|test: REDACTED|||
+                              | *             .|0012|0013|build: REDACTED|||
+                              | *             .|0013|0014|test: REDACTED|||
+                              | *             .|0014|0015|test: REDACTED|||
+                              | *             .|0015|0016|fix: REDACTED|||
+                              | *             .|0016|0017|REDACTED|||
+                              | *             .|0017|0018|REDACTED|||
+                              | *             .|0018|0019|test: REDACTED|||
+                              | *             .|0019|0020|build: REDACTED|||
+                              | *             .|0020|0021|build: REDACTED|||
+                              | *             .|0021|0022|REDACTED|||
+                              | *             .|0022|0023|build: REDACTED|||
+                              | *             .|0023|0004|build: REDACTED|||
+                              |/  
+                              *               .|0004|0024|REDACTED|||
+                              *               .|0024|0025|REDACTED|||
+                              *               .|0025|0026|feat: REDACTED|||
+                              *               .|0026|0027|refactor: REDACTED|||
+                              *               .|0027|0028|refactor: REDACTED|||
+                              *               .|0028|0029|build: REDACTED|||
+                              *               .|0029|0030|feat: REDACTED|||
+                              *               .|0030|0031|build: REDACTED|||
+                              *               .|0031|0032 0033|REDACTED|||
+                              |\  
+                              | *             .|0033|0034|build(tool): REDACTED|||
+                              | *             .|0034|0035|build: REDACTED|||
+                              | *             .|0035|0036|REDACTED|||
+                              | *             .|0036|0037|REDACTED|||
+                              * |             .|0032|0037|REDACTED|||
+                              |/  
+                              *               .|0037|0038|build: REDACTED|| (tag: v1.0.0)|
+                              *               .|0038|0039|build: REDACTED|||
+                              *               .|0039|0040|fix: REDACTED|||
+                              *               .|0040|0041|docs!: REDACTED|||
+                              *               .|0041|0042|fix: REDACTED|||
+                              *               .|0042|0043|build: REDACTED|||
+                              """);
+
     public IEnumerator GetEnumerator()
     {
         yield return new object[] { "Scenario 01", Scenario01 };
@@ -275,5 +326,6 @@ internal sealed class ScenariosFromBuildLogsTestSource : IEnumerable
         yield return new object[] { "Scenario 09 - tag trumps bump on same commit", Scenario09 };
         yield return new object[] { "Scenario 10", Scenario10 };
         yield return new object[] { "Scenario 11", Scenario11 };
+        //yield return new object[] { "Scenario 12", Scenario12 };
     }
 }

--- a/Git2SemVer.MSBuild.Tests/Versioning/Generation/GitHistoryWalking/ScenariosFromBuildLogsTestSource.cs
+++ b/Git2SemVer.MSBuild.Tests/Versioning/Generation/GitHistoryWalking/ScenariosFromBuildLogsTestSource.cs
@@ -263,7 +263,7 @@ internal sealed class ScenariosFromBuildLogsTestSource : IEnumerable
                               """);
 
     /// <summary>
-    ///     Tests conventional commits a path algorithm. 
+    ///     Tests conventional commits a path algorithm.
     /// </summary>
     /// <remarks>
     ///     Actual failure scenario from logs. Was returning 1.0.1 instead of 1.1.0.

--- a/Git2SemVer.MSBuild.Tests/Versioning/Generation/GitHistoryWalking/ScenariosFromBuildLogsTestSource.cs
+++ b/Git2SemVer.MSBuild.Tests/Versioning/Generation/GitHistoryWalking/ScenariosFromBuildLogsTestSource.cs
@@ -263,8 +263,11 @@ internal sealed class ScenariosFromBuildLogsTestSource : IEnumerable
                               """);
 
     /// <summary>
-    ///     Actual failure scenario from logs. Was returning 1.0.1 instead of 1.1.0.
+    ///     Tests conventional commits a path algorithm.
     /// </summary>
+    /// <remarks>
+    ///     Actual failure scenario from logs. Was returning 1.0.1 instead of 1.1.0.
+    /// </remarks>
     public LoggedScenario Scenario12 { get; } =
         new("1.1.0", "0002", """
                               *               .|0002|0003|REDACTED|| (HEAD -> REDACTED_BRANCH, origin/Investigating)|
@@ -326,6 +329,6 @@ internal sealed class ScenariosFromBuildLogsTestSource : IEnumerable
         yield return new object[] { "Scenario 09 - tag trumps bump on same commit", Scenario09 };
         yield return new object[] { "Scenario 10", Scenario10 };
         yield return new object[] { "Scenario 11", Scenario11 };
-        //yield return new object[] { "Scenario 12", Scenario12 };
+        yield return new object[] { "Scenario 12", Scenario12 };
     }
 }

--- a/Git2SemVer.MSBuild.Tests/Versioning/Generation/GitHistoryWalking/ScenariosFromBuildLogsTestSource.cs
+++ b/Git2SemVer.MSBuild.Tests/Versioning/Generation/GitHistoryWalking/ScenariosFromBuildLogsTestSource.cs
@@ -263,7 +263,7 @@ internal sealed class ScenariosFromBuildLogsTestSource : IEnumerable
                               """);
 
     /// <summary>
-    ///     Tests conventional commits a path algorithm.
+    ///     Tests conventional commits a path algorithm. 
     /// </summary>
     /// <remarks>
     ///     Actual failure scenario from logs. Was returning 1.0.1 instead of 1.1.0.

--- a/Git2SemVer.MSBuild.Tests/Versioning/Generation/GitHistoryWalking/VersionHistorySegmentsBuilderTests.cs
+++ b/Git2SemVer.MSBuild.Tests/Versioning/Generation/GitHistoryWalking/VersionHistorySegmentsBuilderTests.cs
@@ -56,10 +56,10 @@ internal class VersionHistorySegmentsBuilderTests : GitHistoryWalkingTestsBase
             var segment = segments[0];
             Assert.That(segment.Id, Is.EqualTo(1));
             Assert.That(segment.Commits, Has.Count.EqualTo(1));
-            Assert.That(segment.FirstCommit.CommitId.ObfuscatedSha, Is.EqualTo("0001"));
-            Assert.That(segment.LastCommit.CommitId.ObfuscatedSha, Is.EqualTo("0001"));
-            Assert.That(segment.To, Has.Count.EqualTo(0));
-            Assert.That(segment.From, Has.Count.EqualTo(2));
+            Assert.That(segment.OldestCommit.CommitId.ObfuscatedSha, Is.EqualTo("0001"));
+            Assert.That(segment.YoungestCommit.CommitId.ObfuscatedSha, Is.EqualTo("0001"));
+            //Assert.That(segment.ChildCommits, Has.Count.EqualTo(0));
+            Assert.That(segment.ParentCommits, Has.Count.EqualTo(2));
             Assert.That(segment.TaggedReleasedVersion, Is.Null);
         });
         Assert.That(segments[1].Commits, Has.Count.EqualTo(1));
@@ -71,9 +71,9 @@ internal class VersionHistorySegmentsBuilderTests : GitHistoryWalkingTestsBase
         {
             var segment = segments[6];
             Assert.That(segment.Commits, Has.Count.EqualTo(3));
-            Assert.That(segment.To, Has.Count.EqualTo(2));
-            Assert.That(segment.To[0].Id, Is.EqualTo(5));
-            Assert.That(segment.To[1].Id, Is.EqualTo(6));
+            //Assert.That(segment.ChildCommits, Has.Count.EqualTo(2));
+            //Assert.That(segment.ChildCommits[0].Id, Is.EqualTo(5));
+            //Assert.That(segment.ChildCommits[1].Id, Is.EqualTo(6));
             Assert.That(segment.TaggedReleasedVersion!.ToString(), Is.EqualTo("0.3.1"));
         });
         Assert.That(segments[7].Commits, Has.Count.EqualTo(1));

--- a/Git2SemVer.MSBuild.Tests/Versioning/Generation/ProjectVersioningTests/HostBuildLabelUpdateUnitTests.cs
+++ b/Git2SemVer.MSBuild.Tests/Versioning/Generation/ProjectVersioningTests/HostBuildLabelUpdateUnitTests.cs
@@ -20,7 +20,7 @@ internal class HostBuildLabelUpdateUnitTests : ProjectVersioningUnitTestsBase
     [TestCase(VersioningMode.SolutionVersioningProject)]
     [TestCase(VersioningMode.SolutionClientProject)]
     [TestCase(VersioningMode.StandAloneProject)]
-    public void DoesNotUpdatesBuildLabel_WhenEnabledButNoBuildSystemVersion(VersioningMode mode)
+    public void DoesNotUpdatesBuildLabel_WhenNoBuildSystemVersion(VersioningMode mode)
     {
         ModeIs(mode);
         Inputs.Setup(x => x.UpdateHostBuildLabel).Returns(true);
@@ -33,7 +33,7 @@ internal class HostBuildLabelUpdateUnitTests : ProjectVersioningUnitTestsBase
     [TestCase(VersioningMode.SolutionVersioningProject)]
     [TestCase(VersioningMode.SolutionClientProject)]
     [TestCase(VersioningMode.StandAloneProject)]
-    public void DoesNotUpdatesBuildLabel_WhenNotEnabledButHasBuildSystemVersion(VersioningMode mode)
+    public void DoesNotUpdatesBuildLabel_WhenNotEnabled(VersioningMode mode)
     {
         ModeIs(mode);
         Inputs.Setup(x => x.UpdateHostBuildLabel).Returns(false);

--- a/Git2SemVer.MSBuild/Git2SemVer.MSBuild.csproj
+++ b/Git2SemVer.MSBuild/Git2SemVer.MSBuild.csproj
@@ -79,7 +79,7 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.4" PrivateAssets="all" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.CodeAnalysis.Scripting" Version="4.11.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="8.0.0" PrivateAssets="all" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.68" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.70" />
     <PackageReference Include="NuGet.Versioning" Version="6.11.1" PrivateAssets="all" />
     <PackageReference Include="Semver" Version="[2.3.0]" PrivateAssets="all" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" PrivateAssets="all" />

--- a/Git2SemVer.MSBuild/Git2SemVer.MSBuild.csproj
+++ b/Git2SemVer.MSBuild/Git2SemVer.MSBuild.csproj
@@ -79,7 +79,7 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.4" PrivateAssets="all" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.CodeAnalysis.Scripting" Version="4.11.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="8.0.0" PrivateAssets="all" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.72" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.68" />
     <PackageReference Include="NuGet.Versioning" Version="6.11.1" PrivateAssets="all" />
     <PackageReference Include="Semver" Version="[2.3.0]" PrivateAssets="all" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" PrivateAssets="all" />

--- a/Git2SemVer.MSBuild/Git2SemVer.MSBuild.csproj
+++ b/Git2SemVer.MSBuild/Git2SemVer.MSBuild.csproj
@@ -79,7 +79,7 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.4" PrivateAssets="all" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.CodeAnalysis.Scripting" Version="4.11.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="8.0.0" PrivateAssets="all" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.73" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-InitialDev.74" />
     <PackageReference Include="NuGet.Versioning" Version="6.11.1" PrivateAssets="all" />
     <PackageReference Include="Semver" Version="[2.3.0]" PrivateAssets="all" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" PrivateAssets="all" />

--- a/Git2SemVer.MSBuild/Git2SemVer.MSBuild.csproj
+++ b/Git2SemVer.MSBuild/Git2SemVer.MSBuild.csproj
@@ -79,7 +79,7 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.4" PrivateAssets="all" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.CodeAnalysis.Scripting" Version="4.11.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="8.0.0" PrivateAssets="all" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.72" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.73" />
     <PackageReference Include="NuGet.Versioning" Version="6.11.1" PrivateAssets="all" />
     <PackageReference Include="Semver" Version="[2.3.0]" PrivateAssets="all" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" PrivateAssets="all" />

--- a/Git2SemVer.MSBuild/Git2SemVer.MSBuild.csproj
+++ b/Git2SemVer.MSBuild/Git2SemVer.MSBuild.csproj
@@ -79,7 +79,7 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.4" PrivateAssets="all" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.CodeAnalysis.Scripting" Version="4.11.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="8.0.0" PrivateAssets="all" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.68" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.72" />
     <PackageReference Include="NuGet.Versioning" Version="6.11.1" PrivateAssets="all" />
     <PackageReference Include="Semver" Version="[2.3.0]" PrivateAssets="all" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" PrivateAssets="all" />

--- a/Git2SemVer.MSBuild/Git2SemVer.MSBuild.csproj
+++ b/Git2SemVer.MSBuild/Git2SemVer.MSBuild.csproj
@@ -79,7 +79,7 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.4" PrivateAssets="all" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.CodeAnalysis.Scripting" Version="4.11.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="8.0.0" PrivateAssets="all" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.70" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.68" />
     <PackageReference Include="NuGet.Versioning" Version="6.11.1" PrivateAssets="all" />
     <PackageReference Include="Semver" Version="[2.3.0]" PrivateAssets="all" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" PrivateAssets="all" />

--- a/Git2SemVer.MSBuild/Versioning/Generation/GitHistoryWalking/IVersionHistoryPath.cs
+++ b/Git2SemVer.MSBuild/Versioning/Generation/GitHistoryWalking/IVersionHistoryPath.cs
@@ -39,6 +39,4 @@ internal interface IVersionHistoryPath
     SemVersion Version { get; }
 
     string ToString();
-
-    IReadOnlyList<VersionHistoryPath> With(IReadOnlyList<VersionHistorySegment> toSegments);
 }

--- a/Git2SemVer.MSBuild/Versioning/Generation/GitHistoryWalking/VersionHistoryPath.cs
+++ b/Git2SemVer.MSBuild/Versioning/Generation/GitHistoryWalking/VersionHistoryPath.cs
@@ -29,9 +29,9 @@ internal sealed class VersionHistoryPath : IVersionHistoryPath
         }
     }
 
-    public Commit FirstCommit => _segments.First().FirstCommit;
+    public Commit FirstCommit => _segments.First().OldestCommit;
 
-    public Commit HeadCommit => _segments.Last().LastCommit;
+    public Commit HeadCommit => _segments.Last().YoungestCommit;
 
     public int Id { get; internal set; }
 
@@ -47,21 +47,21 @@ internal sealed class VersionHistoryPath : IVersionHistoryPath
             $"Path {Id,-3} {segmentIdsString,-20} {commitsCount,5}   {_bumps}   {LastReleasedVersion?.ToString() ?? " none"} -> {GetNextReleaseVersion()}";
     }
 
-    public IReadOnlyList<VersionHistoryPath> With(IReadOnlyList<VersionHistorySegment> toSegments)
-    {
-        if (!toSegments.Any())
-        {
-            return new List<VersionHistoryPath> { this };
-        }
+    //public IReadOnlyList<VersionHistoryPath> With(IReadOnlyList<VersionHistorySegment> toSegments)
+    //{
+    //    if (!toSegments.Any())
+    //    {
+    //        return new List<VersionHistoryPath> { this };
+    //    }
 
-        var paths = new List<VersionHistoryPath>();
-        foreach (var segment in toSegments)
-        {
-            paths.AddRange(With(segment).With(segment.To));
-        }
+    //    var paths = new List<VersionHistoryPath>();
+    //    foreach (var segment in toSegments)
+    //    {
+    //        paths.AddRange(With(segment).With(segment.ChildCommits)); // >>> this is obsolete ... build lookup in paths builder
+    //    }
 
-        return paths;
-    }
+    //    return paths;
+    //}
 
     private ApiChanges AggregateBumps()
     {
@@ -108,7 +108,7 @@ internal sealed class VersionHistoryPath : IVersionHistoryPath
         return version;
     }
 
-    private VersionHistoryPath With(VersionHistorySegment segment)
+    public VersionHistoryPath With(VersionHistorySegment segment)
     {
         var segmentIds = new List<VersionHistorySegment>(_segments) { segment };
         return new VersionHistoryPath(segmentIds.ToArray());

--- a/Git2SemVer.MSBuild/Versioning/Generation/GitHistoryWalking/VersionHistoryPathsBuilder.cs
+++ b/Git2SemVer.MSBuild/Versioning/Generation/GitHistoryWalking/VersionHistoryPathsBuilder.cs
@@ -1,4 +1,7 @@
-﻿using NoeticTools.Common.Logging;
+﻿using System.Security.Cryptography.X509Certificates;
+using NoeticTools.Common.Logging;
+using NoeticTools.Common.Tools.Git;
+using Spectre.Console.Rendering;
 
 
 namespace NoeticTools.Git2SemVer.MSBuild.Versioning.Generation.GitHistoryWalking;
@@ -8,11 +11,36 @@ internal sealed class VersionHistoryPathsBuilder
 {
     private readonly ILogger _logger;
     private readonly IReadOnlyList<VersionHistorySegment> _segments;
+    private readonly ILookup<VersionHistorySegment, VersionHistorySegment> _childSegmentsLookup;
 
     public VersionHistoryPathsBuilder(IReadOnlyList<VersionHistorySegment> segments, ILogger logger)
     {
         _segments = segments;
         _logger = logger;
+
+        var segmentsByYoungestCommit = _segments.ToDictionary(k => k.YoungestCommit.CommitId, v => v);
+        _childSegmentsLookup = GetChildSegmentsLookup(segments, segmentsByYoungestCommit);
+        //var segmentsByOldestCommit = _segments.ToDictionary(k => k.OldestCommit.CommitId, v => v);
+        _startSegments = segments.Where(x => x.ParentCommits.Count == 0 || 
+                                             x.TaggedReleasedVersion != null).ToList();
+    }
+
+    private static ILookup<VersionHistorySegment, VersionHistorySegment> GetChildSegmentsLookup(IReadOnlyList<VersionHistorySegment> segments, Dictionary<CommitId, VersionHistorySegment> segmentsByYoungestCommit)
+    {
+        var childLinks = new List<(VersionHistorySegment parent, VersionHistorySegment child)>();
+        foreach (var segment in segments)
+        {
+            foreach (var parentCommit in segment.ParentCommits)
+            {
+                if (segmentsByYoungestCommit.TryGetValue(parentCommit, out var parentSegment))
+                {
+                    childLinks.Add((parent:parentSegment, child:segment));
+                }
+            }
+        }
+
+        var childSegmentsLookup = childLinks.ToLookup(k => k.parent, v => v.child);
+        return childSegmentsLookup;
     }
 
     public HistoryPaths Build()
@@ -23,14 +51,29 @@ internal sealed class VersionHistoryPathsBuilder
         return new HistoryPaths(paths, _segments);
     }
 
-    private IReadOnlyList<VersionHistorySegment> StartSegments => _segments.Where(x => !x.From.Any()).ToList();
+    private readonly IReadOnlyList<VersionHistorySegment> _startSegments;
+
+    private List<VersionHistoryPath> GetChildPaths(VersionHistorySegment parentSegment, VersionHistoryPath path)
+    {
+        var childSegments = _childSegmentsLookup[parentSegment].ToList();
+        if (childSegments.Count == 0)
+        {
+            return [path];
+        }
+        var pathSegments = new List<VersionHistoryPath>();
+        foreach (var childSegment in childSegments)
+        {
+            pathSegments.AddRange(GetChildPaths(childSegment, path.With(childSegment)));
+        }
+        return pathSegments;
+    }
 
     private List<VersionHistoryPath> FindPaths()
     {
         var paths = new List<VersionHistoryPath>();
-        foreach (var segment in StartSegments)
+        foreach (var startSegment in _startSegments)
         {
-            paths.AddRange(new VersionHistoryPath(segment).With(segment.To));
+            paths.AddRange(GetChildPaths(startSegment, new VersionHistoryPath(startSegment)));
         }
 
         var nextPathId = 1;

--- a/Git2SemVer.Tool.Tests/Git2SemVer.Tool.Tests.csproj
+++ b/Git2SemVer.Tool.Tests/Git2SemVer.Tool.Tests.csproj
@@ -27,7 +27,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.68" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.72" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>

--- a/Git2SemVer.Tool.Tests/Git2SemVer.Tool.Tests.csproj
+++ b/Git2SemVer.Tool.Tests/Git2SemVer.Tool.Tests.csproj
@@ -27,7 +27,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.72" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.68" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>

--- a/Git2SemVer.Tool.Tests/Git2SemVer.Tool.Tests.csproj
+++ b/Git2SemVer.Tool.Tests/Git2SemVer.Tool.Tests.csproj
@@ -27,7 +27,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.70" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.68" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>

--- a/Git2SemVer.Tool.Tests/Git2SemVer.Tool.Tests.csproj
+++ b/Git2SemVer.Tool.Tests/Git2SemVer.Tool.Tests.csproj
@@ -27,7 +27,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.72" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.73" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>

--- a/Git2SemVer.Tool.Tests/Git2SemVer.Tool.Tests.csproj
+++ b/Git2SemVer.Tool.Tests/Git2SemVer.Tool.Tests.csproj
@@ -27,7 +27,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.68" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.70" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>

--- a/Git2SemVer.Tool.Tests/Git2SemVer.Tool.Tests.csproj
+++ b/Git2SemVer.Tool.Tests/Git2SemVer.Tool.Tests.csproj
@@ -27,7 +27,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.73" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-InitialDev.74" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>

--- a/Git2SemVer.Tool/Git2SemVer.Tool.csproj
+++ b/Git2SemVer.Tool/Git2SemVer.Tool.csproj
@@ -75,7 +75,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageReference Include="Injectio" Version="3.3.0" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.68" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.70" />
     <PackageReference Include="Spectre.Console" Version="0.49.1" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.49.1" />
   </ItemGroup>

--- a/Git2SemVer.Tool/Git2SemVer.Tool.csproj
+++ b/Git2SemVer.Tool/Git2SemVer.Tool.csproj
@@ -75,7 +75,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageReference Include="Injectio" Version="3.3.0" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.72" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.68" />
     <PackageReference Include="Spectre.Console" Version="0.49.1" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.49.1" />
   </ItemGroup>

--- a/Git2SemVer.Tool/Git2SemVer.Tool.csproj
+++ b/Git2SemVer.Tool/Git2SemVer.Tool.csproj
@@ -75,7 +75,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageReference Include="Injectio" Version="3.3.0" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.73" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-InitialDev.74" />
     <PackageReference Include="Spectre.Console" Version="0.49.1" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.49.1" />
   </ItemGroup>

--- a/Git2SemVer.Tool/Git2SemVer.Tool.csproj
+++ b/Git2SemVer.Tool/Git2SemVer.Tool.csproj
@@ -75,7 +75,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageReference Include="Injectio" Version="3.3.0" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.72" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.73" />
     <PackageReference Include="Spectre.Console" Version="0.49.1" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.49.1" />
   </ItemGroup>

--- a/Git2SemVer.Tool/Git2SemVer.Tool.csproj
+++ b/Git2SemVer.Tool/Git2SemVer.Tool.csproj
@@ -75,7 +75,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageReference Include="Injectio" Version="3.3.0" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.70" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.68" />
     <PackageReference Include="Spectre.Console" Version="0.49.1" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.49.1" />
   </ItemGroup>

--- a/Git2SemVer.Tool/Git2SemVer.Tool.csproj
+++ b/Git2SemVer.Tool/Git2SemVer.Tool.csproj
@@ -75,7 +75,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageReference Include="Injectio" Version="3.3.0" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.68" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.72" />
     <PackageReference Include="Spectre.Console" Version="0.49.1" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.49.1" />
   </ItemGroup>

--- a/MSBuild.Tasking.Logging/MSBuild.Tasking.Logging.csproj
+++ b/MSBuild.Tasking.Logging/MSBuild.Tasking.Logging.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.Build.Framework" Version="17.11.4" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
     <PackageReference Include="Injectio" Version="3.3.0" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.68" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.72" />
   </ItemGroup>
 
 </Project>

--- a/MSBuild.Tasking.Logging/MSBuild.Tasking.Logging.csproj
+++ b/MSBuild.Tasking.Logging/MSBuild.Tasking.Logging.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.Build.Framework" Version="17.11.4" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
     <PackageReference Include="Injectio" Version="3.3.0" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.70" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.68" />
   </ItemGroup>
 
 </Project>

--- a/MSBuild.Tasking.Logging/MSBuild.Tasking.Logging.csproj
+++ b/MSBuild.Tasking.Logging/MSBuild.Tasking.Logging.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.Build.Framework" Version="17.11.4" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
     <PackageReference Include="Injectio" Version="3.3.0" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.72" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.73" />
   </ItemGroup>
 
 </Project>

--- a/MSBuild.Tasking.Logging/MSBuild.Tasking.Logging.csproj
+++ b/MSBuild.Tasking.Logging/MSBuild.Tasking.Logging.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.Build.Framework" Version="17.11.4" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
     <PackageReference Include="Injectio" Version="3.3.0" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.72" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.68" />
   </ItemGroup>
 
 </Project>

--- a/MSBuild.Tasking.Logging/MSBuild.Tasking.Logging.csproj
+++ b/MSBuild.Tasking.Logging/MSBuild.Tasking.Logging.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.Build.Framework" Version="17.11.4" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
     <PackageReference Include="Injectio" Version="3.3.0" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.68" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.70" />
   </ItemGroup>
 
 </Project>

--- a/MSBuild.Tasking.Logging/MSBuild.Tasking.Logging.csproj
+++ b/MSBuild.Tasking.Logging/MSBuild.Tasking.Logging.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.Build.Framework" Version="17.11.4" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
     <PackageReference Include="Injectio" Version="3.3.0" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.73" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-InitialDev.74" />
   </ItemGroup>
 
 </Project>

--- a/MSBuild.Tasking.Tests/MSBuild.Tasking.Tests.csproj
+++ b/MSBuild.Tasking.Tests/MSBuild.Tasking.Tests.csproj
@@ -15,7 +15,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.68" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.70" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>

--- a/MSBuild.Tasking.Tests/MSBuild.Tasking.Tests.csproj
+++ b/MSBuild.Tasking.Tests/MSBuild.Tasking.Tests.csproj
@@ -15,7 +15,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.70" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.68" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>

--- a/MSBuild.Tasking.Tests/MSBuild.Tasking.Tests.csproj
+++ b/MSBuild.Tasking.Tests/MSBuild.Tasking.Tests.csproj
@@ -15,7 +15,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.72" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.73" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>

--- a/MSBuild.Tasking.Tests/MSBuild.Tasking.Tests.csproj
+++ b/MSBuild.Tasking.Tests/MSBuild.Tasking.Tests.csproj
@@ -15,7 +15,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.68" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.72" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>

--- a/MSBuild.Tasking.Tests/MSBuild.Tasking.Tests.csproj
+++ b/MSBuild.Tasking.Tests/MSBuild.Tasking.Tests.csproj
@@ -15,7 +15,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.72" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.68" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>

--- a/MSBuild.Tasking.Tests/MSBuild.Tasking.Tests.csproj
+++ b/MSBuild.Tasking.Tests/MSBuild.Tasking.Tests.csproj
@@ -15,7 +15,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.73" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-InitialDev.74" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>

--- a/MSBuild.Tasking/MSBuild.Tasking.csproj
+++ b/MSBuild.Tasking/MSBuild.Tasking.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Scripting" Version="4.11.0" />
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="8.0.0" />
     <PackageReference Include="Injectio" Version="3.3.0" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.72" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.73" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MSBuild.Tasking/MSBuild.Tasking.csproj
+++ b/MSBuild.Tasking/MSBuild.Tasking.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Scripting" Version="4.11.0" />
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="8.0.0" />
     <PackageReference Include="Injectio" Version="3.3.0" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.70" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.68" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MSBuild.Tasking/MSBuild.Tasking.csproj
+++ b/MSBuild.Tasking/MSBuild.Tasking.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Scripting" Version="4.11.0" />
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="8.0.0" />
     <PackageReference Include="Injectio" Version="3.3.0" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.72" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.68" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MSBuild.Tasking/MSBuild.Tasking.csproj
+++ b/MSBuild.Tasking/MSBuild.Tasking.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Scripting" Version="4.11.0" />
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="8.0.0" />
     <PackageReference Include="Injectio" Version="3.3.0" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.68" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.72" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MSBuild.Tasking/MSBuild.Tasking.csproj
+++ b/MSBuild.Tasking/MSBuild.Tasking.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Scripting" Version="4.11.0" />
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="8.0.0" />
     <PackageReference Include="Injectio" Version="3.3.0" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.68" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.70" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MSBuild.Tasking/MSBuild.Tasking.csproj
+++ b/MSBuild.Tasking/MSBuild.Tasking.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Scripting" Version="4.11.0" />
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="8.0.0" />
     <PackageReference Include="Injectio" Version="3.3.0" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.73" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-InitialDev.74" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SolutionVersioningProject/SolutionVersioningProject.csproj
+++ b/SolutionVersioningProject/SolutionVersioningProject.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NoeticTools.Git2SemVer.MSBuild" Version="1.0.0" />
+    <PackageReference Include="NoeticTools.Git2SemVer.MSBuild" Version="1.1.0-beta.477" />
   </ItemGroup>
 
 </Project>

--- a/SolutionVersioningProject/SolutionVersioningProject.csproj
+++ b/SolutionVersioningProject/SolutionVersioningProject.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NoeticTools.Git2SemVer.MSBuild" Version="1.1.0-beta.477" />
+    <PackageReference Include="NoeticTools.Git2SemVer.MSBuild" Version="1.0.1-beta.497" />
   </ItemGroup>
 
 </Project>

--- a/TestingCommon/Testing.Common.csproj
+++ b/TestingCommon/Testing.Common.csproj
@@ -18,7 +18,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.70" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.68" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>

--- a/TestingCommon/Testing.Common.csproj
+++ b/TestingCommon/Testing.Common.csproj
@@ -18,7 +18,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.68" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.72" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>

--- a/TestingCommon/Testing.Common.csproj
+++ b/TestingCommon/Testing.Common.csproj
@@ -18,7 +18,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.68" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.70" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>

--- a/TestingCommon/Testing.Common.csproj
+++ b/TestingCommon/Testing.Common.csproj
@@ -18,7 +18,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.72" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.73" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>

--- a/TestingCommon/Testing.Common.csproj
+++ b/TestingCommon/Testing.Common.csproj
@@ -18,7 +18,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.73" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-InitialDev.74" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>

--- a/TestingCommon/Testing.Common.csproj
+++ b/TestingCommon/Testing.Common.csproj
@@ -18,7 +18,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="NoeticTools.Common" Version="0.1.1-alpha-InitialDev.72" />
+    <PackageReference Include="NoeticTools.Common" Version="0.1.1-beta-InitialDev.68" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
### Added

* Added [Cross targeted projects](https://learn.microsoft.com/en-us/nuget/create-packages/multiple-target-frameworks-project-file) support ([#26](https://github.com/NoeticTools/Git2SemVer/issues/26)).
* Added versioning log file ([#26](https://github.com/NoeticTools/Git2SemVer/issues/2)).
* Added [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.2/) support for versioning.

### Fixed

* Git path to last release algorithm issue meant that a git graph segments could be missed ([#30](https://github.com/NoeticTools/Git2SemVer/issues/30)).
* On an uncontrolled host with solution open in Visual Studio, build number updates in background every few seconds ([#28](https://github.com/NoeticTools/Git2SemVer/issues/28)).
* On an uncontrolled host prior build number is reused on first build after new clone ([#27](https://github.com/NoeticTools/Git2SemVer/issues/27)).
* ([#24](https://github.com/NoeticTools/Git2SemVer/issues/24)).


### Known Issues

* Solution configured using `Git2SemVer.Tool` dotnet tool 1.0.0 does not allow for `Git2SemVer.MSBuild` package. Requires manual correction ([#25](https://github.com/NoeticTools/Git2SemVer/issues/25)).

Issue: #26
Issue: #2
Issue: #30
Issue: #28
Issue: #27
Issue: #24